### PR TITLE
Use backend provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you have access to the CQC extractors, you can feed the outputs from the prev
 step to obtain higher quality random numbers:
 
 ```python
-random_bits = output.extract(rng_provider)
+random_bits = output.extract()
 ```
 
 The code above uses the default parameter values, but the extractor is highly 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,7 +62,7 @@ Quick start
   generator = Generator(backend=backend)
   output = generator.sample(num_raw_bits=1024).block_until_ready()
 
-  random_bits = output.extract(rng_provider)
+  random_bits = output.extract()
 
 
 License

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -30,7 +30,7 @@ The current workflow has three parts:
 
    .. code-block:: python
 
-      random_bits = output.extract(rng_provider)
+      random_bits = output.extract()
 
    If you want to examine the final parameters passed to the extractor, you can use:
 

--- a/qiskit_rng/generator_job.py
+++ b/qiskit_rng/generator_job.py
@@ -89,7 +89,8 @@ class GeneratorJob:
                 os.remove(self.saved_fn)
             except Exception:   # pylint: disable=broad-except
                 logger.warning("Unable to delete file %s", self.saved_fn)
-        return GeneratorResult(wsr=self.formatted_wsr, raw_bits_list=self.raw_bits_list)
+        return GeneratorResult(wsr=self.formatted_wsr, raw_bits_list=self.raw_bits_list,
+                               backend=self.backend)
 
     def _format_wsr(self):
         """Format the wsr.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Related to #3, this PR further simplifies the `extract()` method by passing the `backend` information to result and use its provider object, so the user doesn't need to pass it in.


### Details and comments


