### PR TITLE
Accept v2 provider backend

### DIFF
--- a/qiskit_rng/generator.py
+++ b/qiskit_rng/generator.py
@@ -127,7 +127,7 @@ class Generator:
         Raises:
             ValueError: If an input argument is invalid.
         """
-        if not isinstance(self.backend, BaseBackend) or \
+        if not isinstance(self.backend, BaseBackend) and \
                 (HAS_V2_BACKEND and not isinstance(self.backend, Backend)):
             raise ValueError("Backend needs to be a Qiskit `BaseBackend` or `Backend` instance.")
 

--- a/qiskit_rng/generator.py
+++ b/qiskit_rng/generator.py
@@ -41,6 +41,12 @@ from qiskit.providers.ibmq.accountprovider import AccountProvider
 from .generator_job import GeneratorJob
 from .utils import generate_wsr
 
+try:
+    from qiskit.providers.backend import Backend
+    HAS_V2_BACKEND = True
+except ImportError:
+    HAS_V2_BACKEND = False
+
 logger = logging.getLogger(__name__)
 
 
@@ -121,8 +127,9 @@ class Generator:
         Raises:
             ValueError: If an input argument is invalid.
         """
-        if not isinstance(self.backend, BaseBackend):
-            raise ValueError("Backend needs to be a `BaseBackend` instance.")
+        if not isinstance(self.backend, BaseBackend) or \
+                (HAS_V2_BACKEND and not isinstance(self.backend, Backend)):
+            raise ValueError("Backend needs to be a Qiskit `BaseBackend` or `Backend` instance.")
 
         max_shots = self.backend.configuration().max_shots
         num_raw_bits_qubit = int((num_raw_bits + 2)/3)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Qiskit now has a new (v2) base backend. This PR updates `Generator` to accept both v1 and v2 interface.


### Details and comments


