### PR TITLE
change the transpile 'optimization_level' from 2 to 1

### DIFF
--- a/qiskit_rng/generator.py
+++ b/qiskit_rng/generator.py
@@ -173,7 +173,7 @@ class Generator:
         Returns:
             An IBMQ managed job set or a job.
         """
-        transpiled = transpile(circuits, backend=self.backend, optimization_level=2)
+        transpiled = transpile(circuits, backend=self.backend, optimization_level=1)
         transpiled = [transpiled] if not isinstance(transpiled, list) else transpiled
 
         if isinstance(self.backend, IBMQBackend):


### PR DESCRIPTION
This change is designed to avoid the generation of circuit including gates not available on the selected backend.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
I noticed that the problem arises just with transpile level set on 2. I suggested to insert 1 but it works also with 0 and 3. 

