### PR TITLE
Update required Qiskit terra version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 qiskit-ibmq-provider>=0.10
+qiskit-terra>=0.16.2

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ import os
 from setuptools import setup, find_packages
 
 REQUIREMENTS = [
-    "qiskit-ibmq-provider>=0.10"
+    "qiskit-ibmq-provider>=0.10",
+    "qiskit-terra>=0.16.2"
 ]
 
 # Read long description from README.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
qiskit-terra 0.16.2 fixed the basis gate issue with `optimization_level=2`, as described in #10. This PR updates the required qiskit-terra version to ensure the fix is installed. 

Closes #10.
### Details and comments


